### PR TITLE
set php version check to 8.0

### DIFF
--- a/core/modules/modMrpBdePicking.class.php
+++ b/core/modules/modMrpBdePicking.class.php
@@ -145,7 +145,7 @@ class modMrpBdePicking extends DolibarrModules
 		$this->langfiles = array("mrpbdepicking@mrpbdepicking");
 
 		// Prerequisites
-		$this->phpmin = array(7, 0); // Minimum version of PHP required by module
+		$this->phpmin = array(8, 0); // Minimum version of PHP required by module
 		$this->need_dolibarr_version = array(11, -3); // Minimum version of Dolibarr required by module
 		$this->need_javascript_ajax = 0;
 


### PR DESCRIPTION
module will not work on php <8

had the problem and realized that my test system was php 7.4